### PR TITLE
Enable deep sleep for TM2019

### DIFF
--- a/TM2019-RedmiBook_Pro_15S/RMACZ5B0P0909/patch.diff
+++ b/TM2019-RedmiBook_Pro_15S/RMACZ5B0P0909/patch.diff
@@ -1,5 +1,5 @@
---- dsdt.dsl.origin	2022-11-01 22:05:31.339229808 +0800
-+++ dsdt.dsl	2022-11-01 22:06:51.590021552 +0800
+--- dsdt.dsl.origin	2022-11-13 08:36:30.610840597 +0300
++++ dsdt.dsl	2022-11-13 08:47:03.909784196 +0300
 @@ -18,7 +18,7 @@
   *     Compiler ID      "ACPI"
   *     Compiler Version 0x00040000 (262144)
@@ -9,7 +9,34 @@
  {
      External (_SB_.ALIB, MethodObj)    // 2 Arguments
      External (_SB_.APTS, MethodObj)    // 1 Arguments
-@@ -4404,7 +4404,6 @@
+@@ -744,20 +744,13 @@
+         Zero, 
+         Zero
+     })
+-    If ((CNSB == Zero))
++    Name (_S3, Package (0x04)  // _S3_: S3 System State
+     {
+-        If ((DAS3 == One))
+-        {
+-            Name (_S3, Package (0x04)  // _S3_: S3 System State
+-            {
+-                0x03, 
+-                0x03, 
+-                Zero, 
+-                Zero
+-            })
+-        }
+-    }
+-
++        0x03, 
++        0x03, 
++        Zero, 
++        Zero
++    })
+     Name (_S4, Package (0x04)  // _S4_: S4 System State
+     {
+         0x04, 
+@@ -4404,7 +4397,6 @@
                              ALBH (0x06, (FPPT * 0x03E8))
                              ALBH (0x07, (SPPT * 0x03E8))
                              ALBH (0x05, (HSPL * 0x03E8))
@@ -17,7 +44,7 @@
                              Return (One)
                          }
  
-@@ -4688,7 +4687,6 @@
+@@ -4688,7 +4680,6 @@
                              ALBH (0x06, 0x4E20)
                              ALBH (0x07, 0x4E20)
                              ALBH (0x05, 0x00051C98)

--- a/fixes/acpi/install.sh
+++ b/fixes/acpi/install.sh
@@ -13,6 +13,10 @@ clean() {
 }
 
 grub_mem_sleep() {
+    if [ "$(dmidecode -s baseboard-product-name)" != "TM2019" ]; then
+        return
+    fi
+
     if grep mem_sleep_default /etc/default/grub >/dev/null; then
         prerr "There is a mem_sleep_default parameter in /etc/default/grub!"
         prerr "You should manually add mem_sleep_default=deep to GRUB_CMDLINE_LINUX_DEFAULT if needed."

--- a/fixes/acpi/install.sh
+++ b/fixes/acpi/install.sh
@@ -12,6 +12,22 @@ clean() {
     rm -f dsdt* ssdt* acpi_override
 }
 
+grub_mem_sleep() {
+    if grep mem_sleep_default /etc/default/grub >/dev/null; then
+        prerr "There is a mem_sleep_default parameter in /etc/default/grub!"
+        prerr "You should manually add mem_sleep_default=deep to GRUB_CMDLINE_LINUX_DEFAULT if needed."
+        return
+    fi
+
+    if grep 'GRUB_CMDLINE_LINUX_DEFAULT' /etc/default/grub >/dev/null; then
+        sed -ire 's/GRUB_CMDLINE_LINUX_DEFAULT="(.+)"/GRUB_CMDLINE_LINUX_DEFAULT="\1 mem_sleep_default=deep"/g' /etc/default/grub
+    else
+        echo "GRUB_CMDLINE_LINUX_DEFAULT=\"mem_sleep_default=deep\"" >>/etc/default/grub
+    fi
+    
+    return
+}
+
 update_grub() {
     local OVERRIDE_ACPI_OSI="$TOP_DIR/${PRODUCTION_NAME}/${BIOS_VERSION}/override_acpi_osi.sh"
 
@@ -20,14 +36,20 @@ update_grub() {
     fi
 
     if grep acpi_override /etc/default/grub >/dev/null; then
+        prerr "There is a acpi_override in /etc/default/grub!"
+        prerr "You should you should first run uninstall.sh to remove old intallation."
+        prerr "Or you can manually add mem_sleep_default=deep to GRUB_CMDLINE_LINUX_DEFAULT"
+        prerr "and GRUB_EARLY_INITRD_LINUX_CUSTOM=\"acpi_override\" if needed."
         return
     fi
-
+    
     if grep 'GRUB_EARLY_INITRD_LINUX_CUSTOM=""' /etc/default/grub >/dev/null; then
         sed -i 's/GRUB_EARLY_INITRD_LINUX_CUSTOM=""/GRUB_EARLY_INITRD_LINUX_CUSTOM="acpi_override"/g' /etc/default/grub
     else
         echo "GRUB_EARLY_INITRD_LINUX_CUSTOM=\"acpi_override\"" >>/etc/default/grub
     fi
+
+    grub_mem_sleep
 
     /bin/sh "$TOP_DIR/scripts/update-grub.sh"
 }

--- a/fixes/acpi/uninstall.sh
+++ b/fixes/acpi/uninstall.sh
@@ -7,6 +7,9 @@ fi
 
 rm /boot/acpi_override
 sed -i 's/acpi_override//g' /etc/default/grub
-sed -i 's/mem_sleep_default=deep//g' /etc/default/grub
+
+if [ "$(dmidecode -s baseboard-product-name)" == "TM2019" ]; then
+    sed -i 's/mem_sleep_default=deep//g' /etc/default/grub
+fi
 
 /bin/sh "$TOP_DIR/scripts/update-grub.sh"

--- a/fixes/acpi/uninstall.sh
+++ b/fixes/acpi/uninstall.sh
@@ -7,5 +7,6 @@ fi
 
 rm /boot/acpi_override
 sed -i 's/acpi_override//g' /etc/default/grub
+sed -i 's/mem_sleep_default=deep//g' /etc/default/grub
 
 /bin/sh "$TOP_DIR/scripts/update-grub.sh"

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ if test ! -e ".skip_update"; then
 
     elif test "$ID" = "manjaro" -o "$ID" = "arch" -o "$ID_LIKE" = "arch"; then
         pacman -Syyu
-        pacman -S dkms bash make acpica dmidecode mokutil patch diffutils cpio
+        pacman -S --needed dkms bash make acpica dmidecode mokutil patch diffutils cpio
 
     elif test "$ID" = "opensuse-tumbleweed" -o "$ID_LIKE" = "opensuse suse"; then
         zypper refresh


### PR DESCRIPTION
Updated acpi patch for TM2019-RedmiBook_Pro_15S using [this article](https://nns.ee/blog/2020/10/18/acpi-patching.html).
Also altered install.sh and uninstall.sh to set kernel parameter `mem_sleep_default=deep` for grub for TM2019 model.
Slightly edited package install command, so it won't reinstall packages.