### PR TITLE
add RMARB5B1P1111

### DIFF
--- a/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/override_acpi_osi.sh
+++ b/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/override_acpi_osi.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if ! grep acpi_osi /etc/default/grub >/dev/null; then
+    echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX acpi_osi=! acpi_osi=Linux\"" >>/etc/default/grub
+fi

--- a/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/patch.archlinux.diff
+++ b/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/patch.archlinux.diff
@@ -1,0 +1,59 @@
+diff --git dsdt.dsl b/dsdt.dsl
+index 95aea35..849e147 100644
+--- dsdt.dsl
++++ b/dsdt.dsl
+@@ -18,7 +18,7 @@
+  *     Compiler ID      "ACPI"
+  *     Compiler Version 0x00040000 (262144)
+  */
+-DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
++DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000003)
+ {
+     External (_SB_.ALIB, MethodObj)    // 2 Arguments
+     External (_SB_.APTS, MethodObj)    // 1 Arguments
+@@ -4084,6 +4084,18 @@
+                 Device (ACP)
+                 {
+                     Name (_ADR, 0x05)  // _ADR: Address
++                    Name (_DSD, Package (0x02)  // _DSD: Device-Specific Data
++                    {
++                        ToUUID ("5025030f-842f-4ab4-a561-99a5189762d0") /* Unknown UUID */,
++                        Package (0x01)
++                        {
++                            Package (0x02)
++                            {
++                                "AcpDmicConnected",
++                                One
++                            }
++                        }
++                    })
+                 }
+
+                 Device (AZAL)
+@@ -5093,7 +5093,7 @@ DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
+                             0x01,               // Alignment
+                             0x01,               // Length
+                             )
+-                        IRQ (Edge, ActiveLow, Shared, )
++                        Interrupt (ResourceConsumer, Edge, ActiveLow, Shared, , ,)
+                             {1}
+                     })
+                 }
+@@ -5471,7 +5471,7 @@ DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
+                     {
+                         If ((DPTC == One))
+                         {
+-                            Name (PPPB, Buffer (0x12){})
++                            Name (PPPB, Buffer (0x11){})
+                             CreateWordField (PPPB, Zero, SSZE)
+                             CreateByteField (PPPB, 0x02, PMDH)
+                             CreateDWordField (PPPB, 0x03, VCLT)
+@@ -5479,7 +5479,7 @@ DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
+                             CreateDWordField (PPPB, 0x08, VMCL)
+                             CreateByteField (PPPB, 0x0C, PMDB)
+                             CreateDWordField (PPPB, 0x0D, P3TL)
+-                            SSZE = 0x12
++                            SSZE = 0x11
+                             PMDH = 0x0B
+                             VCLT = Arg0
+                             PMDI = 0x0C

--- a/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/patch.diff
+++ b/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/patch.diff
@@ -1,0 +1,59 @@
+diff --git dsdt.dsl b/dsdt.dsl
+index 95aea35..849e147 100644
+--- dsdt.dsl
++++ b/dsdt.dsl
+@@ -18,7 +18,7 @@
+  *     Compiler ID      "ACPI"
+  *     Compiler Version 0x00040000 (262144)
+  */
+-DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
++DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000003)
+ {
+     External (_SB_.ALIB, MethodObj)    // 2 Arguments
+     External (_SB_.APTS, MethodObj)    // 1 Arguments
+@@ -4084,6 +4084,18 @@
+                 Device (ACP)
+                 {
+                     Name (_ADR, 0x05)  // _ADR: Address
++                    Name (_DSD, Package (0x02)  // _DSD: Device-Specific Data
++                    {
++                        ToUUID ("5025030f-842f-4ab4-a561-99a5189762d0") /* Unknown UUID */,
++                        Package (0x01)
++                        {
++                            Package (0x02)
++                            {
++                                "AcpDmicConnected",
++                                One
++                            }
++                        }
++                    })
+                 }
+
+                 Device (AZAL)
+@@ -5093,7 +5093,7 @@ DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
+                             0x01,               // Alignment
+                             0x01,               // Length
+                             )
+-                        IRQ (Edge, ActiveLow, Shared, )
++                        Interrupt (ResourceConsumer, Edge, ActiveLow, Shared, , ,)
+                             {1}
+                     })
+                 }
+@@ -5471,7 +5471,7 @@ DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
+                     {
+                         If ((DPTC == One))
+                         {
+-                            Name (PPPB, Buffer (0x12){})
++                            Name (PPPB, Buffer (0x11){})
+                             CreateWordField (PPPB, Zero, SSZE)
+                             CreateByteField (PPPB, 0x02, PMDH)
+                             CreateDWordField (PPPB, 0x03, VCLT)
+@@ -5479,7 +5479,7 @@ DefinitionBlock ("", "DSDT", 1, "XMCC  ", "XMCC2114", 0x00000002)
+                             CreateDWordField (PPPB, 0x08, VMCL)
+                             CreateByteField (PPPB, 0x0C, PMDB)
+                             CreateDWordField (PPPB, 0x0D, P3TL)
+-                            SSZE = 0x12
++                            SSZE = 0x11
+                             PMDH = 0x0B
+                             VCLT = Arg0
+                             PMDI = 0x0C

--- a/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/url.txt
+++ b/TM2113-Redmi_Book_Pro_15_2022/RMARB5B1P1111/url.txt
@@ -1,0 +1,2 @@
+Service: https://www.mi.com/service/notebook/drivers/A39S
+BIOS: https://cdn.cnbj1.fds.api.mi-img.com/mibook-drivers/BIOS/A28SA39S/20220729/RMARB5B0P0B0B_B1P0404.zip


### PR DESCRIPTION
Add support BIOS RMARB5B1P1111 in patch ACPI. Made on the basis RMARB5B1P0С0С. Simple link to RMARB5B1P0С0С doesn't work.